### PR TITLE
Fixed funky case list UI bug.

### DIFF
--- a/src/screens/case_list_screen/caseList.css
+++ b/src/screens/case_list_screen/caseList.css
@@ -129,7 +129,7 @@
     color: #FFF;
     text-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
     font-family: Inter;
-    font-size: 32px;
+    font-size: 25px;
     font-style: normal;
     font-weight: 700;
     line-height: normal;
@@ -163,7 +163,7 @@
     color: #FFF;
     text-align: center;
     font-family: Inter;
-    font-size: 24px;
+    font-size: 22px;
     font-style: normal;
     font-weight: 700;
     line-height: normal;
@@ -179,7 +179,7 @@
     color: #FFF;
     text-align: center;
     font-family: Inter;
-    font-size: 20px;
+    font-size: 18px;
     font-style: normal;
     font-weight: 700;
     line-height: normal;


### PR DESCRIPTION
This fixes bug #85.

This bug was a super easy fix.

The thing that was causing the issue was the fact that when I first created the CSS for this screen, I did not expect the "Last Update: X, Status: X" text to be longer than 2 lines. So, when I originally tested it with fake data that was only 2 lines long, it was fine. The problem with it being 3 lines long is that it kind of overflows the container and that pushes everything down a few pixels. Therefore, the easiest fix that I could think of was to simply make the text smaller so that it properly fits everything on 2 lines. I also made the button text a little smaller so that they look more appealing with the new changes.

**TLDR**: The "Last Update" text was so long that it was overflowing the container in CSS.