### PR TITLE
Fix case list does not sort bug.

### DIFF
--- a/src/screens/case_list_screen/caseList.tsx
+++ b/src/screens/case_list_screen/caseList.tsx
@@ -169,9 +169,9 @@ export default function CaseListScreen(props): JSX.Element {
                     .filter(caseForDisplay => !showActiveOnly || caseForDisplay.status === 'Open')
                     .sort((a, b) => {
                         if (sortOrder === 'Duration: Low to High') {
-                            return parseInt(a.duration) - parseInt(b.duration)
+                            return a.duration.localeCompare(b.duration)
                         } else if (sortOrder === 'Duration: High to Low') {
-                            return parseInt(b.duration) - parseInt(a.duration)
+                            return b.duration.localeCompare(a.duration)
                         } else {
                             return 0
                         }


### PR DESCRIPTION
closes #87

Ok so the issue was that we were trying to sort the list by converting the duration (which is a string) to an integer and comparing them. The problem is that when you try to cast the string, all you get back is 0 (see the screenshot of my debug statements below). 

![image](https://github.com/wge123/locating-survivors/assets/72236249/6bae4784-c01a-4c85-8afc-d57ad9488a85)


So, to fix the bug I just refactored the logic so that we sort the duration strings in alphabetical order rather than using the casted integers.