### PR TITLE
Fixes #131

### DIFF
--- a/amplify/backend/function/handlerWrapper/src/index.js
+++ b/amplify/backend/function/handlerWrapper/src/index.js
@@ -321,10 +321,6 @@ exports.handler = async (event) => {
             return apiResponse(400, { message: error.message })
         }
 
-    } else {
-
-        return apiResponse(400, { message: 'Success, but no email sent' })
-
     }
 }
 function apiResponse(statusCode, body) {

--- a/src/screens/case_list_screen/caseList.css
+++ b/src/screens/case_list_screen/caseList.css
@@ -5,6 +5,7 @@
     background: #1C1B1FBF;
     display: grid;
     grid-template-columns: 400px auto;
+    position: relative;
 }
 
 #cl-left-pane {
@@ -81,6 +82,15 @@
     padding-left: 15px;
     padding-right: 15px;
     overflow-y: scroll;
+    max-height: calc(100vh - 120px);
+}
+#new-case-button-container {
+    position: absolute;
+    bottom: 0;
+    right: 0;
+    width: 1100px;
+    height: 120px;
+    background: #555457;
 }
 
 #cl-mc-bottom-button {

--- a/src/screens/case_list_screen/caseList.tsx
+++ b/src/screens/case_list_screen/caseList.tsx
@@ -183,7 +183,9 @@ export default function CaseListScreen(props): JSX.Element {
                         </>
                     ))
                 }
-                <button id='cl-mc-bottom-button' onClick={() => navigateToNewCaseScreen()}>New Case...</button>
+                <div id='new-case-button-container'>
+                    <button id='cl-mc-bottom-button' onClick={navigateToNewCaseScreen}>New Case...</button>
+                </div>
             </div>
             {isLoading && (
                 <div className="loading-overlay">

--- a/src/ui-components/LoginButton.d.ts
+++ b/src/ui-components/LoginButton.d.ts
@@ -5,8 +5,17 @@
  **************************************************************************/
 
 import * as React from "react";
-import { EscapeHatchProps } from "@aws-amplify/ui-react/internal";
 import { TextProps, ViewProps } from "@aws-amplify/ui-react";
+export declare type EscapeHatchProps = {
+    [elementHierarchy: string]: Record<string, unknown>;
+} | null;
+export declare type VariantValues = {
+    [key: string]: string;
+};
+export declare type Variant = {
+    variantValues: VariantValues;
+    overrides: EscapeHatchProps;
+};
 export declare type PrimitiveOverrideProps<T> = Partial<T> & React.DOMAttributes<HTMLDivElement>;
 export declare type LoginButtonOverridesProps = {
     LoginButton?: PrimitiveOverrideProps<ViewProps>;

--- a/src/ui-components/MiddlePane.d.ts
+++ b/src/ui-components/MiddlePane.d.ts
@@ -5,8 +5,17 @@
  **************************************************************************/
 
 import * as React from "react";
-import { EscapeHatchProps } from "@aws-amplify/ui-react/internal";
 import { TextProps, ViewProps } from "@aws-amplify/ui-react";
+export declare type EscapeHatchProps = {
+    [elementHierarchy: string]: Record<string, unknown>;
+} | null;
+export declare type VariantValues = {
+    [key: string]: string;
+};
+export declare type Variant = {
+    variantValues: VariantValues;
+    overrides: EscapeHatchProps;
+};
 export declare type PrimitiveOverrideProps<T> = Partial<T> & React.DOMAttributes<HTMLDivElement>;
 export declare type MiddlePaneOverridesProps = {
     MiddlePane?: PrimitiveOverrideProps<ViewProps>;


### PR DESCRIPTION
So here is the situation. I originally fixed the new case button to not drag with the screen when minimizing the screen and to always stay in place but I noticed this issue below.

<img width="1440" alt="Screenshot 2023-11-04 at 1 09 57 AM" src="https://github.com/wge123/locating-survivors/assets/106719554/f091653c-fbcf-45d0-ba42-9c4a7d660cd0">

When the screen is full of cases the button covers the export and view buttons, and for the last case the export and view button can barely be clicked as you have to align the screen properly with that little bit of space below the new case button.

So my solution to the original issue and this new found issue was to add a container to the button so the new case button never overlaps cases.

<img width="1440" alt="Screenshot 2023-11-04 at 12 38 14 AM" src="https://github.com/wge123/locating-survivors/assets/106719554/a8c30795-d5c4-4466-8b83-0e0e4f5dd5b7">
<img width="1436" alt="Screenshot 2023-11-04 at 12 50 14 AM" src="https://github.com/wge123/locating-survivors/assets/106719554/89c6d1fa-4b0c-4f29-b45b-a13308370c1f">

Above are a couple examples of the container for the button with colors matching the left pane and/or the background of where the cases are listed. I think the container with the color matching the left pane looks a little cleaner but I wanted to show the container with the darker color too because with a case list with very few cases there looks to be no difference at all.

<img width="1440" alt="Screenshot 2023-11-04 at 1 05 28 AM" src="https://github.com/wge123/locating-survivors/assets/106719554/2f2b1a47-84cc-4471-9565-15d74260b040">

Let me know your guys thoughts and if you like either of these solutions. Another idea I had was to throw the new case button at the bottom of the case list but with a lot of cases where you have to scroll could be inconvenient for the user.