### PR TITLE
Remove Sensitive Information From Our App Logs

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -27,7 +27,7 @@ export default function App() {
 
     useEffect(() => {
         Hub.listen('auth', (event) => {
-            console.log('auth event', event)
+            console.log('Hub just received an auth event: ', event.payload.message)
             const userAttributes = event.payload
             const userData = event.payload.event
             if (userData instanceof CognitoUser) {

--- a/src/screens/2FA_screen/2FA.tsx
+++ b/src/screens/2FA_screen/2FA.tsx
@@ -15,12 +15,11 @@ export default function TwoFactorAuthenticationScreen(props: twoFactorAuthentica
         try {
             // Confirm the 2FA code that the user typed in.
             const mfaResponse = await Auth.confirmSignIn(props.authResponse, mfaCode, 'SOFTWARE_TOKEN_MFA')
-            console.log('User authentication response with 2FA: ', mfaResponse)
+            console.log('User authenticated with 2FA.')
             if (mfaResponse) {
                 Auth.currentAuthenticatedUser()
                     .then(user => {
                         const attributes = user.attributes
-                        console.log(attributes)
                         Hub.dispatch('auth', { event: mfaResponse , attributes })
                     })
                     .catch(err => console.log(err))

--- a/src/screens/login_screen/login.tsx
+++ b/src/screens/login_screen/login.tsx
@@ -17,7 +17,7 @@ export default function LoginScreen() {
         setIsLoading(true)
         try {
             const response = await Auth.signIn(username, password)
-            console.log('User authentication response: ', response)
+            console.log('User authenticated with username and password. 2FA has not been verified yet.')
             setAuthresponse(response)
         } catch (error) {
             console.log('User authentication attempt failed. ' + error)


### PR DESCRIPTION
Closes #185... and **_partially_** completes #186.

I believe that we should still have logs in our app just in case there is a bug and we need to do some debugging, however, I do agree that we should refrain from displaying sensitive user information in such logs. So, this PR aims to remedy most of that.